### PR TITLE
refactor: migrate from React Context to useSyncExternalStore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.5.1",
-        "styled-components": "^6.3.11"
+        "styled-components": "^6.3.11",
+        "use-sync-external-store": "^1.6.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -18,6 +19,7 @@
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "@types/use-sync-external-store": "^1.5.0",
         "@vitejs/plugin-react": "^6.0.0",
         "eslint": "^9.39.4",
         "eslint-config-prettier": "^10.1.8",
@@ -1367,6 +1369,13 @@
       "version": "4.2.7",
       "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.7.tgz",
       "integrity": "sha512-VgDNokpBoKF+wrdvhAAfS55OMQpL6QRglwTwNC3kIgBrzZxA4WsFj+2eLfEA/uMUDzBcEhYmjSbwQakn/i3ajA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-5dyB8nLC/qogMrlCizZnYWQTA4lnb/v+It+sqNl5YnSRAPMlIqY/X0Xn+gZw8vOL+TgTTr28VEbn3uf8fUtAkw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -4350,6 +4359,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
   },
   "dependencies": {
     "classnames": "^2.5.1",
-    "styled-components": "^6.3.11"
+    "styled-components": "^6.3.11",
+    "use-sync-external-store": "^1.6.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
@@ -60,6 +61,7 @@
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@types/use-sync-external-store": "^1.5.0",
     "@vitejs/plugin-react": "^6.0.0",
     "eslint": "^9.39.4",
     "eslint-config-prettier": "^10.1.8",

--- a/src/Components/ColumnCell.tsx
+++ b/src/Components/ColumnCell.tsx
@@ -1,6 +1,6 @@
 import Draggable from './Draggable'
 import type { DraggableProps } from './Draggable'
-import { useTable } from './TableContainer/useTable'
+import { useTableStore } from './TableContainer/useTable'
 import React, { useMemo, memo } from 'react'
 import type { ReactNode } from 'react'
 
@@ -15,12 +15,9 @@ interface ColumnCellProps {
 
 const ColumnCell: React.FC<ColumnCellProps> = memo(
   ({ children, width, style, className, ...props }) => {
-    const { state } = useTable()
+    const defaultSizing = useTableStore((s) => s.options.defaultSizing)
 
-    const colCellWidth = useMemo(
-      () => width ?? state.options.defaultSizing,
-      [width, state.options.defaultSizing],
-    )
+    const colCellWidth = useMemo(() => width ?? defaultSizing, [width, defaultSizing])
 
     const draggableStyles = useMemo(
       () => ({

--- a/src/Components/Draggable.tsx
+++ b/src/Components/Draggable.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, memo, useRef, useEffect } from 'react'
 import type { ReactElement, CSSProperties, ReactNode } from 'react'
-import { useTable } from './TableContainer/useTable'
+import { useTableStore, useTableDispatch } from './TableContainer/useTable'
 import { isIndexOutOfRange } from './utils'
 import type { DragType } from '../hooks/types'
 
@@ -14,29 +14,23 @@ export interface DraggableProps {
 }
 
 const Draggable: React.FC<DraggableProps> = memo(({ children, id, index, type, styles = {} }) => {
-  const { state, dispatch } = useTable()
+  const draggedID = useTableStore((s) => s.dragged.draggedID)
+  const isDraggingState = useTableStore((s) => s.dragged.isDragging)
+  const rowDragRange = useTableStore((s) => s.options.rowDragRange)
+  const columnDragRange = useTableStore((s) => s.options.columnDragRange)
+  const dispatch = useTableDispatch()
+
   const isDragging = useMemo(
-    () => String(id) === String(state.dragged.draggedID) && state.dragged.isDragging,
-    [id, state.dragged.draggedID, state.dragged.isDragging],
+    () => String(id) === String(draggedID) && isDraggingState,
+    [id, draggedID, isDraggingState],
   )
 
   const disableDrag = useMemo(
     () =>
       type === 'row'
-        ? isIndexOutOfRange(index, state.options.rowDragRange.start, state.options.rowDragRange.end)
-        : isIndexOutOfRange(
-            index,
-            state.options.columnDragRange.start,
-            state.options.columnDragRange.end,
-          ),
-    [
-      index,
-      state.options.columnDragRange.end,
-      state.options.columnDragRange.start,
-      state.options.rowDragRange.end,
-      state.options.rowDragRange.start,
-      type,
-    ],
+        ? isIndexOutOfRange(index, rowDragRange.start, rowDragRange.end)
+        : isIndexOutOfRange(index, columnDragRange.start, columnDragRange.end),
+    [index, columnDragRange.end, columnDragRange.start, rowDragRange.end, rowDragRange.start, type],
   )
 
   // Detect if this draggable contains a DragHandle — cached once after mount

--- a/src/Components/RowCell.tsx
+++ b/src/Components/RowCell.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, memo } from 'react'
-import { useTable } from './TableContainer/useTable'
+import { useTableStore } from './TableContainer/useTable'
 
 interface RowCellProps {
   children?: React.ReactNode
@@ -15,17 +15,20 @@ interface RowCellProps {
 const RowCell: React.FC<RowCellProps> = memo(
   ({ children, style, className, isClone, ...props }) => {
     const { index } = props
-    const { state } = useTable()
+    const columnIds = useTableStore((s) => s.columnIds)
+    const widths = useTableStore((s) => s.widths)
+    const defaultSizing = useTableStore((s) => s.options.defaultSizing)
+    const draggedID = useTableStore((s) => s.dragged.draggedID)
 
-    const columnId = useMemo(() => state.columnIds[index] ?? '', [state.columnIds, index])
+    const columnId = useMemo(() => columnIds[index] ?? '', [columnIds, index])
     const rowCellWidth = useMemo(
-      () => state.widths[index] ?? state.options.defaultSizing,
-      [state.widths, index, state.options.defaultSizing],
+      () => widths[index] ?? defaultSizing,
+      [widths, index, defaultSizing],
     )
 
     const isDragging = useMemo(
-      () => (isClone ? false : columnId === state.dragged.draggedID),
-      [isClone, columnId, state.dragged.draggedID],
+      () => (isClone ? false : columnId === draggedID),
+      [isClone, columnId, draggedID],
     )
 
     const styles = useMemo(

--- a/src/Components/TableBody.tsx
+++ b/src/Components/TableBody.tsx
@@ -11,7 +11,7 @@ import React, {
   type ReactNode,
 } from 'react'
 import { createPortal } from 'react-dom'
-import { useTable } from './TableContainer/useTable'
+import { useTableStore, useTableDispatch } from './TableContainer/useTable'
 import useAutoScroll from '../hooks/useAutoScroll'
 
 interface TableBodyProps {
@@ -46,10 +46,15 @@ const TableBody = forwardRef<HTMLDivElement, TableBodyProps>(
     const [bodyScrollHeight, setBodyScrollHeight] = useState(0)
     const localRef = useRef<HTMLDivElement>(null)
     useImperativeHandle(ref, () => localRef.current!, [])
-    const { state, dispatch } = useTable()
+
+    const sourceIndex = useTableStore((s) => s.dragged.sourceIndex)
+    const dragType = useTableStore((s) => s.dragType)
+    const isDragging = useTableStore((s) => s.dragged.isDragging)
+    const refs = useTableStore((s) => s.refs)
+    const dispatch = useTableDispatch()
 
     const clone = useMemo(() => {
-      if (state.dragged.sourceIndex === null) return null
+      if (sourceIndex === null) return null
 
       const collectBodyRows = (node: ReactNode): ReactElement<RowProps>[] => {
         const rows: ReactElement<RowProps>[] = []
@@ -75,7 +80,7 @@ const TableBody = forwardRef<HTMLDivElement, TableBodyProps>(
           .filter(
             (cell): cell is ReactElement<CellProps> =>
               React.isValidElement<CellProps>(cell) &&
-              String(cell.props.index) === String(state.dragged.sourceIndex),
+              String(cell.props.index) === String(sourceIndex),
           )
           .map((cell) => React.cloneElement(cell, { key: cell.props.index, isClone: true }))
 
@@ -85,23 +90,23 @@ const TableBody = forwardRef<HTMLDivElement, TableBodyProps>(
           children: filteredCells,
         })
       })
-    }, [children, state.dragged.sourceIndex])
+    }, [children, sourceIndex])
 
     useEffect(() => {
       dispatch({ type: 'setRef', refName: 'bodyRef', value: localRef })
     }, [dispatch, localRef])
 
-    const { BodyScrollHandle } = useAutoScroll(state.refs)
+    const { BodyScrollHandle } = useAutoScroll(refs)
 
     const InnerBodyDefaultStyles = useMemo<CSSProperties>(
       () => ({
         overflowX: 'auto',
         overflowY: 'auto',
         flex: 1,
-        userSelect: state.dragged.isDragging ? 'none' : 'auto',
+        userSelect: isDragging ? 'none' : 'auto',
         ...style,
       }),
-      [state.dragged.isDragging, style],
+      [isDragging, style],
     )
 
     useEffect(() => {
@@ -120,8 +125,8 @@ const TableBody = forwardRef<HTMLDivElement, TableBodyProps>(
     }, [localRef, children])
     return (
       <React.Fragment>
-        {state.dragType === 'column' &&
-          state.refs.cloneRef?.current &&
+        {dragType === 'column' &&
+          refs.cloneRef?.current &&
           createPortal(
             <div
               className="body clone-body"
@@ -132,7 +137,7 @@ const TableBody = forwardRef<HTMLDivElement, TableBodyProps>(
                 {clone && React.Children.toArray(clone)}
               </div>
             </div>,
-            state.refs.cloneRef.current,
+            refs.cloneRef.current,
           )}
         <div className={`body ${className ?? ''}`} style={BODY_STYLES}>
           <div

--- a/src/Components/TableContainer/index.tsx
+++ b/src/Components/TableContainer/index.tsx
@@ -1,8 +1,10 @@
-import React, { useImperativeHandle, useMemo, forwardRef, useLayoutEffect } from 'react'
+import React, { useImperativeHandle, useMemo, forwardRef, useLayoutEffect, useState } from 'react'
 import type { CSSProperties, ReactNode } from 'react'
 import { Styles } from './styles'
-import { useEffect, useRef, useReducer } from 'react'
-import { TableContext } from './useTable'
+import { useEffect, useRef } from 'react'
+import { useSyncExternalStore } from 'use-sync-external-store/shim'
+import { StoreContext } from './useTable'
+import { createTableStore } from './store'
 import useDragContextEvents from '../../hooks/useDragContextEvents'
 import type { TableAction, TableState, DragEndResult, DragRange } from '../../hooks/types'
 
@@ -86,7 +88,7 @@ function tableReducer(state: TableState, action: TableAction): TableState {
   }
 }
 
-const INITIAL_STATE = {
+const INITIAL_STATE: TableState = {
   clone: null,
   dragged: {
     initial: { x: 0, y: 0 },
@@ -108,8 +110,8 @@ const INITIAL_STATE = {
   },
   bodyScrollBarWidth: 0,
   options: DEFAULT_OPTIONS,
-  widths: [] as number[],
-  columnIds: [] as string[],
+  widths: [],
+  columnIds: [],
 }
 
 const TABLE_DEFAULT_STYLES: CSSProperties = {
@@ -135,8 +137,9 @@ const TableProvider = forwardRef<HTMLDivElement, TableProviderProps>(
 
     useImperativeHandle(ref, () => localRef.current!, [])
 
-    const [state, dispatch] = useReducer(tableReducer, INITIAL_STATE)
-    const value = useMemo(() => ({ state, dispatch }), [state])
+    const [store] = useState(() => createTableStore(tableReducer, INITIAL_STATE))
+    const state = useSyncExternalStore(store.subscribe, store.getState)
+    const dispatch = store.dispatch
 
     useEffect(() => {
       dispatch({ type: 'setRef', refName: 'tableRef', value: localRef })
@@ -146,7 +149,7 @@ const TableProvider = forwardRef<HTMLDivElement, TableProviderProps>(
         refName: 'placeholderRef',
         value: placeholderRef,
       })
-    }, [localRef])
+    }, [localRef, dispatch])
 
     useEffect(() => {
       const updateTableDimensions = () => {
@@ -167,13 +170,13 @@ const TableProvider = forwardRef<HTMLDivElement, TableProviderProps>(
       return () => {
         window.removeEventListener('resize', updateTableDimensions)
       }
-    }, [localRef])
+    }, [localRef, dispatch])
 
     useEffect(() => {
       if (options) {
         dispatch({ type: 'setOptions', value: options })
       }
-    }, [options])
+    }, [options, dispatch])
 
     const { dragStart, touchStart } = useDragContextEvents(
       state.refs,
@@ -227,7 +230,7 @@ const TableProvider = forwardRef<HTMLDivElement, TableProviderProps>(
     )
 
     return (
-      <TableContext.Provider value={value}>
+      <StoreContext.Provider value={store}>
         <Styles className={state.dragged.isDragging ? 'is-dragging' : ''}>
           <div
             id="portalroot"
@@ -257,7 +260,7 @@ const TableProvider = forwardRef<HTMLDivElement, TableProviderProps>(
             {children}
           </div>
         </Styles>
-      </TableContext.Provider>
+      </StoreContext.Provider>
     )
   },
 )

--- a/src/Components/TableContainer/store.ts
+++ b/src/Components/TableContainer/store.ts
@@ -1,0 +1,29 @@
+import type { TableState, TableAction } from '../../hooks/types'
+
+export interface TableStore {
+  getState: () => TableState
+  dispatch: (action: TableAction) => void
+  subscribe: (listener: () => void) => () => void
+}
+
+export function createTableStore(
+  reducer: (state: TableState, action: TableAction) => TableState,
+  initialState: TableState,
+): TableStore {
+  let state = initialState
+  const listeners = new Set<() => void>()
+
+  return {
+    getState: () => state,
+    dispatch(action) {
+      state = reducer(state, action)
+      listeners.forEach((l) => l())
+    },
+    subscribe(listener) {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    },
+  }
+}

--- a/src/Components/TableContainer/useTable.tsx
+++ b/src/Components/TableContainer/useTable.tsx
@@ -1,12 +1,26 @@
 import { createContext, useContext } from 'react'
-import type { TableContextType } from '../../hooks/types'
+import { useSyncExternalStore } from 'use-sync-external-store/shim'
+import type { TableStore } from './store'
+import type { TableState, TableAction } from '../../hooks/types'
 
-export const TableContext = createContext<TableContextType | undefined>(undefined)
+export const StoreContext = createContext<TableStore | null>(null)
 
+export const useTableStore = <T,>(selector: (state: TableState) => T): T => {
+  const store = useContext(StoreContext)
+  if (!store) throw new Error('useTableStore must be used within TableProvider')
+  return useSyncExternalStore(store.subscribe, () => selector(store.getState()))
+}
+
+export const useTableDispatch = (): ((action: TableAction) => void) => {
+  const store = useContext(StoreContext)
+  if (!store) throw new Error('useTableDispatch must be used within TableProvider')
+  return store.dispatch
+}
+
+// subscribes to full state — prefer useTableStore(selector) for perf
 export const useTable = () => {
-  const context = useContext(TableContext)
-  if (context === undefined) {
-    throw new Error('useTable must be used within a TableProvider')
-  }
-  return context
+  const store = useContext(StoreContext)
+  if (!store) throw new Error('useTable must be used within a TableProvider')
+  const state = useSyncExternalStore(store.subscribe, store.getState)
+  return { state, dispatch: store.dispatch }
 }

--- a/src/Components/TableHeader.tsx
+++ b/src/Components/TableHeader.tsx
@@ -7,8 +7,8 @@ import React, {
   type ReactNode,
   useCallback,
 } from 'react'
-import { useTable } from './TableContainer/useTable.tsx'
-import useAutoScroll from '../hooks/useAutoScroll.ts'
+import { useTableStore, useTableDispatch } from './TableContainer/useTable'
+import useAutoScroll from '../hooks/useAutoScroll'
 import './style.css'
 
 interface TableHeaderProps {
@@ -21,7 +21,11 @@ const TableHeader = forwardRef<HTMLDivElement, TableHeaderProps>(
   ({ children, style, className }, ref) => {
     const localRef = useRef(null)
     const resolvedRef = ref || localRef
-    const { state, dispatch } = useTable()
+
+    const bodyScrollBarWidth = useTableStore((s) => s.bodyScrollBarWidth)
+    const isDragging = useTableStore((s) => s.dragged.isDragging)
+    const refs = useTableStore((s) => s.refs)
+    const dispatch = useTableDispatch()
 
     const getRefCurrent = useCallback((ref: typeof resolvedRef): HTMLDivElement | null => {
       if ('current' in ref) return ref.current
@@ -38,7 +42,7 @@ const TableHeader = forwardRef<HTMLDivElement, TableHeaderProps>(
       }
     }, [dispatch])
 
-    const { HeaderScrollHandle } = useAutoScroll(state.refs)
+    const { HeaderScrollHandle } = useAutoScroll(refs)
 
     const defaultStyles = {
       display: 'flex',
@@ -49,11 +53,11 @@ const TableHeader = forwardRef<HTMLDivElement, TableHeaderProps>(
       () => ({
         overflow: 'hidden',
         display: 'flex',
-        paddingRight: `${state.bodyScrollBarWidth}px`,
-        userSelect: state.dragged.isDragging ? ('none' as const) : ('auto' as const),
+        paddingRight: `${bodyScrollBarWidth}px`,
+        userSelect: isDragging ? ('none' as const) : ('auto' as const),
         ...style,
       }),
-      [state.bodyScrollBarWidth, state.dragged.isDragging, style],
+      [bodyScrollBarWidth, isDragging, style],
     )
 
     useLayoutEffect(() => {

--- a/src/Components/index.ts
+++ b/src/Components/index.ts
@@ -5,7 +5,7 @@ import TableBody from './TableBody'
 import BodyRow from './BodyRow'
 import RowCell from './RowCell'
 import DragHandle from './DragHandle'
-export { useTable } from './TableContainer/useTable'
+export { useTable, useTableStore, useTableDispatch } from './TableContainer/useTable'
 export { TableContainer, TableHeader, ColumnCell, TableBody, BodyRow, RowCell, DragHandle }
 
 // Re-export public types for consumers

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -1,4 +1,4 @@
-import type { Dispatch, MutableRefObject, ReactElement, RefObject } from 'react'
+import type { MutableRefObject, ReactElement, RefObject } from 'react'
 
 // --- Drag & Table types ---
 export type DragType = 'row' | 'column'
@@ -112,9 +112,4 @@ export interface ColumnItem {
 export interface Point {
   x: number
   y: number
-}
-
-export interface TableContextType {
-  state: TableState
-  dispatch: Dispatch<TableAction>
 }


### PR DESCRIPTION
## Type

- [ ] 🚀 Feature
- [ ] 🐛 Bug Fix
- [x] ♻️ Refactor (Performance)
- [ ] 📝 Documentation
- [ ] 🧹 Chore (dependencies, CI, tooling)

## Description

This PR fundamentally changes how flexitablesort handles internal state, moving from a standard React Context to a high-performance, dependency-free Pub/Sub architecture using useSyncExternalStore.


## Related Issue

Closes # 


## Screenshots / Demos

<!-- If applicable, add screenshots or screen recordings to help explain your changes. -->

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style (ran `npm run format`)
- [ ] I have run `npm run lint` with no errors
- [ ] I have tested my changes locally
- [ ] I have updated the documentation if needed
- [ ] I have updated the `CHANGELOG.md` if applicable
- [ ] My changes do not introduce any new warnings
