### PR TITLE
refactor: replace React.cloneElement with native DOM cloneNode for dr…

### DIFF
--- a/src/Components/Draggable.tsx
+++ b/src/Components/Draggable.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, memo, useRef, useEffect } from 'react'
-import type { ReactElement, CSSProperties, ReactNode } from 'react'
-import { useTableStore, useTableDispatch } from './TableContainer/useTable'
-import { isIndexOutOfRange, isScrollbarClick } from './utils'
+import type { CSSProperties, ReactNode } from 'react'
+import { useTableStore } from './TableContainer/useTable'
+import { isIndexOutOfRange } from './utils'
 import type { DragType } from '../hooks/types'
 
 export interface DraggableProps {
@@ -18,7 +18,6 @@ const Draggable: React.FC<DraggableProps> = memo(({ children, id, index, type, s
   const isDraggingState = useTableStore((s) => s.dragged.isDragging)
   const rowDragRange = useTableStore((s) => s.options.rowDragRange)
   const columnDragRange = useTableStore((s) => s.options.columnDragRange)
-  const dispatch = useTableDispatch()
 
   const isDragging = useMemo(
     () => String(id) === String(draggedID) && isDraggingState,
@@ -35,11 +34,6 @@ const Draggable: React.FC<DraggableProps> = memo(({ children, id, index, type, s
 
   // Detect if this draggable contains a DragHandle — cached once after mount
   const innerRef = useRef<HTMLDivElement>(null)
-  const hasHandleRef = useRef(false)
-
-  useEffect(() => {
-    hasHandleRef.current = !!innerRef.current?.querySelector('[data-drag-handle]')
-  }, [children])
 
   // Transform is applied directly via DOM in useDragContextEvents
   const draggableInnerStyles: CSSProperties = useMemo(
@@ -59,38 +53,12 @@ const Draggable: React.FC<DraggableProps> = memo(({ children, id, index, type, s
     }
   }, [children, disableDrag, isDragging])
 
-  const onPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
-    // Skip real touch events — touch drag clone is set via long-press in beginDrag
-    if (event.pointerType === 'touch') return
-    // Only respond to primary (left) mouse button — ignore right-click and middle-click
-    if (event.button !== 0) return
-    if (disableDrag) return
-
-    // Synthetic pointerdown from mobile long-press (pointerType: 'mouse' but isTrusted: false)
-    // Always allow clone creation — the long-press already validated the drag intent
-    const isSyntheticFromTouch = !event.isTrusted
-
-    if (!isSyntheticFromTouch) {
-      const target = event.target as HTMLElement
-      // Ignore clicks on scrollbar tracks/thumbs — must check before cloning
-      if (isScrollbarClick(event.clientX, event.clientY, target)) return
-      // If this draggable has a DragHandle, only set clone if the click originated from the handle
-      if (hasHandleRef.current && !target.closest('[data-drag-handle]')) return
-    }
-
-    dispatch({
-      type: 'setClone',
-      value: React.cloneElement(children as ReactElement),
-    })
-  }
-
   return (
     <div
       className="draggable"
       data-id={id}
       data-index={index}
       data-type={type}
-      onPointerDown={onPointerDown}
       data-disabled={disableDrag ? 'true' : 'false'}
       style={styles}
     >

--- a/src/Components/RowCell.tsx
+++ b/src/Components/RowCell.tsx
@@ -5,50 +5,41 @@ interface RowCellProps {
   children?: React.ReactNode
   width?: number
   index: number
-  isClone?: true
   style?: React.CSSProperties
   className?: string
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [propName: string]: any
 }
 
-const RowCell: React.FC<RowCellProps> = memo(
-  ({ children, style, className, isClone, ...props }) => {
-    const { index } = props
-    const columnIds = useTableStore((s) => s.columnIds)
-    const widths = useTableStore((s) => s.widths)
-    const defaultSizing = useTableStore((s) => s.options.defaultSizing)
-    const draggedID = useTableStore((s) => s.dragged.draggedID)
+const RowCell: React.FC<RowCellProps> = memo(({ children, style, className, ...props }) => {
+  const { index } = props
+  const columnIds = useTableStore((s) => s.columnIds)
+  const widths = useTableStore((s) => s.widths)
+  const defaultSizing = useTableStore((s) => s.options.defaultSizing)
+  const draggedID = useTableStore((s) => s.dragged.draggedID)
 
-    const columnId = useMemo(() => columnIds[index] ?? '', [columnIds, index])
-    const rowCellWidth = useMemo(
-      () => widths[index] ?? defaultSizing,
-      [widths, index, defaultSizing],
-    )
+  const columnId = useMemo(() => columnIds[index] ?? '', [columnIds, index])
+  const rowCellWidth = useMemo(() => widths[index] ?? defaultSizing, [widths, index, defaultSizing])
 
-    const isDragging = useMemo(
-      () => (isClone ? false : columnId === draggedID),
-      [isClone, columnId, draggedID],
-    )
+  const isDragging = useMemo(() => columnId === draggedID, [columnId, draggedID])
 
-    const styles = useMemo(
-      () => ({
-        display: 'inline-flex',
-        opacity: isDragging ? 0 : 1,
-        width: `${rowCellWidth}px`,
-        flex: `${rowCellWidth} 0 auto`,
-        ...style,
-      }),
-      [isDragging, rowCellWidth, style],
-    )
+  const styles = useMemo(
+    () => ({
+      display: 'inline-flex',
+      opacity: isDragging ? 0 : 1,
+      width: `${rowCellWidth}px`,
+      flex: `${rowCellWidth} 0 auto`,
+      ...style,
+    }),
+    [isDragging, rowCellWidth, style],
+  )
 
-    return (
-      <div className={`td ${className ?? ''}`} style={styles} data-col-index={index}>
-        {children}
-      </div>
-    )
-  },
-)
+  return (
+    <div className={`td ${className ?? ''}`} style={styles} data-col-index={index}>
+      {children}
+    </div>
+  )
+})
 
 RowCell.displayName = 'RowCell'
 export default RowCell

--- a/src/Components/TableBody.tsx
+++ b/src/Components/TableBody.tsx
@@ -2,15 +2,11 @@ import React, {
   forwardRef,
   useEffect,
   useImperativeHandle,
-  useLayoutEffect,
   useMemo,
   useRef,
-  useState,
   type CSSProperties,
-  type ReactElement,
   type ReactNode,
 } from 'react'
-import { createPortal } from 'react-dom'
 import { useTableStore, useTableDispatch } from './TableContainer/useTable'
 import useAutoScroll from '../hooks/useAutoScroll'
 
@@ -18,21 +14,6 @@ interface TableBodyProps {
   children: ReactNode
   style?: React.CSSProperties
   className?: string
-}
-
-interface RowProps {
-  id: string | number
-  index: string | number
-  children: ReactNode
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any // allows extra props
-}
-
-interface CellProps {
-  index: string | number
-  isClone?: boolean
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any
 }
 
 const BODY_STYLES: CSSProperties = {
@@ -43,54 +24,12 @@ const BODY_STYLES: CSSProperties = {
 
 const TableBody = forwardRef<HTMLDivElement, TableBodyProps>(
   ({ children, style, className }, ref) => {
-    const [bodyScrollHeight, setBodyScrollHeight] = useState(0)
     const localRef = useRef<HTMLDivElement>(null)
     useImperativeHandle(ref, () => localRef.current!, [])
 
-    const sourceIndex = useTableStore((s) => s.dragged.sourceIndex)
-    const dragType = useTableStore((s) => s.dragType)
     const isDragging = useTableStore((s) => s.dragged.isDragging)
     const refs = useTableStore((s) => s.refs)
     const dispatch = useTableDispatch()
-
-    const clone = useMemo(() => {
-      if (sourceIndex === null) return null
-
-      const collectBodyRows = (node: ReactNode): ReactElement<RowProps>[] => {
-        const rows: ReactElement<RowProps>[] = []
-        React.Children.forEach(node, (child) => {
-          if (!React.isValidElement<RowProps>(child)) return
-          if (
-            child.props.id !== undefined &&
-            child.props.index !== undefined &&
-            child.props.children
-          ) {
-            rows.push(child)
-          } else if (child.props.children) {
-            rows.push(...collectBodyRows(child.props.children))
-          }
-        })
-        return rows
-      }
-
-      const bodyRows = collectBodyRows(children)
-
-      return bodyRows.map((row) => {
-        const filteredCells = React.Children.toArray(row.props.children)
-          .filter(
-            (cell): cell is ReactElement<CellProps> =>
-              React.isValidElement<CellProps>(cell) &&
-              String(cell.props.index) === String(sourceIndex),
-          )
-          .map((cell) => React.cloneElement(cell, { key: cell.props.index, isClone: true }))
-
-        return React.cloneElement(row, {
-          key: row.props.id,
-          ...row.props,
-          children: filteredCells,
-        })
-      })
-    }, [children, sourceIndex])
 
     useEffect(() => {
       dispatch({ type: 'setRef', refName: 'bodyRef', value: localRef })
@@ -118,39 +57,18 @@ const TableBody = forwardRef<HTMLDivElement, TableBodyProps>(
       }
     }, [dispatch, localRef])
 
-    useLayoutEffect(() => {
-      if (localRef.current) {
-        setBodyScrollHeight(localRef.current.scrollHeight)
-      }
-    }, [localRef, children])
     return (
-      <React.Fragment>
-        {dragType === 'column' &&
-          refs.cloneRef?.current &&
-          createPortal(
-            <div
-              className="body clone-body"
-              data-droppableid={'body'}
-              style={{ overflow: 'hidden', flex: 1 }}
-            >
-              <div className="rbody" style={{ height: bodyScrollHeight, position: 'relative' }}>
-                {clone && React.Children.toArray(clone)}
-              </div>
-            </div>,
-            refs.cloneRef.current,
-          )}
-        <div className={`body ${className ?? ''}`} style={BODY_STYLES}>
-          <div
-            className="ibody"
-            style={InnerBodyDefaultStyles}
-            data-droppableid={'body'}
-            onScroll={BodyScrollHandle}
-            ref={localRef}
-          >
-            {children}
-          </div>
+      <div className={`body ${className ?? ''}`} style={BODY_STYLES}>
+        <div
+          className="ibody"
+          style={InnerBodyDefaultStyles}
+          data-droppableid={'body'}
+          onScroll={BodyScrollHandle}
+          ref={localRef}
+        >
+          {children}
         </div>
-      </React.Fragment>
+      </div>
     )
   },
 )

--- a/src/Components/TableContainer/index.tsx
+++ b/src/Components/TableContainer/index.tsx
@@ -1,4 +1,4 @@
-import React, { useImperativeHandle, useMemo, forwardRef, useLayoutEffect, useState } from 'react'
+import React, { useImperativeHandle, useMemo, forwardRef, useState } from 'react'
 import type { CSSProperties, ReactNode } from 'react'
 import { Styles } from './styles'
 import { useEffect, useRef } from 'react'
@@ -28,8 +28,6 @@ const DEFAULT_OPTIONS = {
 
 function tableReducer(state: TableState, action: TableAction): TableState {
   switch (action.type) {
-    case 'setClone':
-      return { ...state, clone: action.value }
     case 'setDragged':
       return { ...state, dragged: { ...state.dragged, ...action.value } }
     case 'setDragType':
@@ -70,7 +68,6 @@ function tableReducer(state: TableState, action: TableAction): TableState {
     case 'dragEnd':
       return {
         ...state,
-        clone: null,
         dragged: {
           initial: { x: 0, y: 0 },
           translate: { x: 0, y: 0 },
@@ -89,7 +86,6 @@ function tableReducer(state: TableState, action: TableAction): TableState {
 }
 
 const INITIAL_STATE: TableState = {
-  clone: null,
   dragged: {
     initial: { x: 0, y: 0 },
     translate: { x: 0, y: 0 },
@@ -187,16 +183,6 @@ const TableProvider = forwardRef<HTMLDivElement, TableProviderProps>(
       onDragEnd,
     )
 
-    useLayoutEffect(() => {
-      if (state.clone && state.dragType === 'row') {
-        const cloneEl = cloneRef.current as HTMLElement | null
-        const bodyEl = state.refs.bodyRef?.current as HTMLElement | null
-        if (cloneEl && bodyEl) {
-          cloneEl.scrollLeft = bodyEl.scrollLeft
-        }
-      }
-    }, [state.clone, state.dragType, state.refs.bodyRef])
-
     // transform is set directly via DOM in useDragContextEvents
     const cloneStyles = useMemo<CSSProperties>(
       () => ({
@@ -239,9 +225,7 @@ const TableProvider = forwardRef<HTMLDivElement, TableProviderProps>(
               visibility: state.dragged.isDragging ? 'visible' : 'hidden',
             }}
             ref={cloneRef}
-          >
-            <div style={{ flexShrink: 0, order: -1 }}>{state.clone}</div>
-          </div>
+          />
           <div ref={placeholderRef} style={PLACEHOLDER_STYLES}>
             {renderPlaceholder ? (
               renderPlaceholder()

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -1,4 +1,4 @@
-import type { MutableRefObject, ReactElement, RefObject } from 'react'
+import type { MutableRefObject, RefObject } from 'react'
 
 // --- Drag & Table types ---
 export type DragType = 'row' | 'column'
@@ -47,7 +47,6 @@ export interface HookRefs {
   placeholderRef: RefObject<HTMLDivElement | null>
 }
 export interface TableState {
-  clone: ReactElement | null
   dragged: DraggedState
   dragType: DragType | null
   rect: RectState
@@ -61,7 +60,6 @@ export interface TableState {
 
 // --- Actions ---
 export type TableAction =
-  | { type: 'setClone'; value: ReactElement | null }
   | { type: 'setDragged'; value: Partial<DraggedState> }
   | { type: 'setDragType'; value: DragType | null }
   | { type: 'setTableDimensions'; value: TableDimensions }

--- a/src/hooks/useDragContextEvents.tsx
+++ b/src/hooks/useDragContextEvents.tsx
@@ -86,7 +86,6 @@ const useDragContextEvents = (
       const id = draggableEl.dataset.id
       const sourceIndex = +draggableEl.dataset.index!
       const dtype = draggableEl.dataset.type as DragType | undefined
-      const isTouch = e.type === 'touchstart'
 
       // Reset refs
       dragTypeRef.current = dtype ?? null
@@ -95,12 +94,6 @@ const useDragContextEvents = (
       cloneBodyElRef.current = null
       prevTargetIndexRef.current = null
       dragEndFiredRef.current = false
-
-      if (isTouch) {
-        draggableEl.dispatchEvent(
-          new PointerEvent('pointerdown', { bubbles: true, pointerType: 'mouse' }),
-        )
-      }
 
       const scrollOffset = dtype === 'row' ? (refs.bodyRef?.current?.scrollLeft ?? 0) : 0
       const itemRect = draggableEl.getBoundingClientRect()
@@ -129,7 +122,55 @@ const useDragContextEvents = (
       if (tableEl) tableEl.style.touchAction = 'none'
 
       const cloneEl = refs.cloneRef?.current
-      if (cloneEl) cloneEl.style.transform = `translate(${translate.x}px, ${translate.y}px)`
+      if (cloneEl) {
+        cloneEl.innerHTML = ''
+        cloneEl.style.transform = `translate(${translate.x}px, ${translate.y}px)`
+
+        // Build native DOM clone (no React re-render needed)
+        // Important: clone the *inner content* (children of Draggable), NOT draggableEl itself.
+        // draggableEl may carry virtual-scroll positioning (position:absolute, top:Xpx, transform)
+        // that would misplace the clone inside #portalroot.
+        // This mirrors what React.cloneElement(children) did in the old Draggable.onPointerDown.
+        if (dtype === 'row') {
+          // children of Draggable = first child of draggableEl's inner div = the .tr element
+          const rowContent = draggableEl.firstElementChild?.firstElementChild
+          if (rowContent) cloneEl.appendChild(rowContent.cloneNode(true))
+        } else if (dtype === 'column' && body) {
+          const idx = String(sourceIndex)
+
+          // Header: clone just the .th element — mirrors React.cloneElement(children) from Draggable
+          const thEl = draggableEl.querySelector('.th')
+          if (thEl) {
+            const headerWrapper = document.createElement('div')
+            headerWrapper.style.flexShrink = '0'
+            headerWrapper.style.order = '-1'
+            headerWrapper.appendChild(thEl.cloneNode(true))
+            cloneEl.appendChild(headerWrapper)
+          }
+
+          // Body column strip — same structure the React portal produced
+          const bodyWrapper = document.createElement('div')
+          bodyWrapper.style.overflow = 'hidden'
+          bodyWrapper.style.flex = '1'
+
+          const inner = document.createElement('div')
+          inner.className = 'rbody'
+          inner.style.height = `${body.scrollHeight}px`
+          inner.style.position = 'relative'
+
+          body.querySelectorAll('[data-type="row"]').forEach((row) => {
+            const rowClone = row.cloneNode(true) as HTMLElement
+            rowClone.querySelectorAll('[data-col-index]').forEach((cell) => {
+              if (cell.getAttribute('data-col-index') !== idx) cell.remove()
+            })
+            inner.appendChild(rowClone)
+          })
+
+          bodyWrapper.appendChild(inner)
+          cloneEl.appendChild(bodyWrapper)
+          cloneBodyElRef.current = bodyWrapper
+        }
+      }
 
       if (refs.tableRef?.current) {
         dispatch({
@@ -150,7 +191,7 @@ const useDragContextEvents = (
         },
       })
 
-      // Sync clone scroll
+      // Sync clone scroll with body
       const bodyScrollLeft = body?.scrollLeft ?? 0
       const bodyScrollTop = body?.scrollTop ?? 0
       requestAnimationFrame(() => {
@@ -158,9 +199,8 @@ const useDragContextEvents = (
         if (!c) return
         if (dtype === 'row') {
           c.scrollLeft = bodyScrollLeft
-        } else {
-          const cb = c.querySelector('.clone-body') as HTMLElement | null
-          if (cb) cb.scrollTop = bodyScrollTop
+        } else if (cloneBodyElRef.current) {
+          cloneBodyElRef.current.scrollTop = bodyScrollTop
         }
       })
     },
@@ -308,11 +348,6 @@ const useDragContextEvents = (
       const bodyScrollTop = container.scrollTop
       const cloneEl = refs.cloneRef?.current
 
-      // Cache .clone-body reference for column drags (querySelector is expensive)
-      if (cloneEl && dragTypeRef.current === 'column' && !cloneBodyElRef.current) {
-        cloneBodyElRef.current = cloneEl.querySelector('.clone-body') as HTMLElement | null
-      }
-
       // DOM writes
       if (cloneEl) {
         cloneEl.style.transform = `translate(${clientX - initial.x}px, ${clientY - initial.y}px)`
@@ -435,18 +470,10 @@ const useDragContextEvents = (
         cloneEl.style.transform = 'translate(0px, 0px)'
         cloneEl.style.visibility = ''
         cloneEl.scrollLeft = 0
+        cloneEl.innerHTML = ''
       }
     }
   }, [dragged.isDragging, clearShiftTransforms, refs.cloneRef])
-
-  // Chrome Android needs touch-action:none set before the first pointerdown, so this is permanent
-  // useEffect(() => {
-  //   const body = refs.bodyRef?.current
-  //   if (body) body.style.touchAction = 'none'
-  //   return () => {
-  //     if (body) body.style.touchAction = ''
-  //   }
-  // }, [refs.bodyRef])
 
   // pointermove is rAF-throttled so we don't block the main thread on every event
   useEffect(() => {


### PR DESCRIPTION
…ag ghost

## Type

<!-- Check the one that applies -->

- [ ] 🚀 Feature
- [ ] 🐛 Bug Fix
- [x] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] 🧹 Chore (dependencies, CI, tooling)

## Description

Replaces the React.cloneElement-based drag ghost with a native DOM cloneNode
approach. The ghost is now built synchronously inside beginDrag before any React
dispatch, eliminating the extra render cycle and the entire setClone/isClone
machinery.

## Related Issue

<!-- Link to the issue this PR addresses, e.g. "Closes #42" -->

Closes #19 

## Changes

- Remove `setClone` action, `state.clone`, and `isClone` prop from RowCell
- Build row ghost by cloning the inner `.tr` content (not the `.draggable` wrapper)
  so virtual-scroll positioning styles don't bleed into #portalroot
- Build column header ghost by cloning only the `.th` element — matches what
  React.cloneElement(children) produced from inside Draggable
- Remove fake `pointerdown` dispatch for touch — no longer needed since
  beginDrag handles both mouse and touch paths directly


## Screenshots / Demos

<!-- If applicable, add screenshots or screen recordings to help explain your changes. -->

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style (ran `npm run format`)
- [x] I have run `npm run lint` with no errors
- [x] I have tested my changes locally
- [ ] I have updated the documentation if needed
- [ ] I have updated the `CHANGELOG.md` if applicable
- [x] My changes do not introduce any new warnings
